### PR TITLE
Add racing game configuration and car performance rules

### DIFF
--- a/src/main/java/com/calendar/game/CarAttributes.java
+++ b/src/main/java/com/calendar/game/CarAttributes.java
@@ -1,0 +1,45 @@
+package com.calendar.game;
+
+public class CarAttributes {
+    private static final int TOTAL_ASSIGNABLE_POINTS = 10;
+
+    private final int speedPoints;
+    private final int staminaPoints;
+    private final int recoveryPoints;
+    private final int acceleratorPoints;
+
+    public CarAttributes(int speedPoints, int staminaPoints, int recoveryPoints, int acceleratorPoints) {
+        this.speedPoints = speedPoints;
+        this.staminaPoints = staminaPoints;
+        this.recoveryPoints = recoveryPoints;
+        this.acceleratorPoints = acceleratorPoints;
+        validate();
+    }
+
+    private void validate() {
+        if (speedPoints < 0 || staminaPoints < 0 || recoveryPoints < 0 || acceleratorPoints < 0) {
+            throw new IllegalArgumentException("Attribute points cannot be negative.");
+        }
+
+        int usedPoints = speedPoints + staminaPoints + recoveryPoints + acceleratorPoints;
+        if (usedPoints != TOTAL_ASSIGNABLE_POINTS) {
+            throw new IllegalArgumentException("Exactly 10 points must be assigned across all attributes.");
+        }
+    }
+
+    public int getSpeedPoints() {
+        return speedPoints;
+    }
+
+    public int getStaminaPoints() {
+        return staminaPoints;
+    }
+
+    public int getRecoveryPoints() {
+        return recoveryPoints;
+    }
+
+    public int getAcceleratorPoints() {
+        return acceleratorPoints;
+    }
+}

--- a/src/main/java/com/calendar/game/CarPerformance.java
+++ b/src/main/java/com/calendar/game/CarPerformance.java
@@ -1,0 +1,71 @@
+package com.calendar.game;
+
+public class CarPerformance {
+    private static final int BASE_MAX_SPEED_KMH = 80;
+    private static final int SPEED_PER_POINT_KMH = 5;
+
+    private static final int STAMINA_LOW_SPEED_SECONDS = 40;
+    private static final int STAMINA_MEDIUM_SPEED_SECONDS = 30;
+    private static final int STAMINA_HIGH_SPEED_SECONDS = 20;
+    private static final int STAMINA_PER_POINT_SECONDS = 5;
+
+    private static final int BASE_RECOVERY_SECONDS_FOR_10_PERCENT = 2;
+    private static final int RECOVERY_REDUCTION_PER_POINT_SECONDS = 3;
+
+    private static final int ACCELERATOR_USES_PER_POINT_PER_3_SECONDS = 1;
+
+    private final int maxSpeedKmh;
+    private final int staminaDurationSeconds;
+    private final int recoverySecondsFor10PercentStamina;
+    private final int acceleratorUsesPer3Seconds;
+
+    private CarPerformance(int maxSpeedKmh,
+                           int staminaDurationSeconds,
+                           int recoverySecondsFor10PercentStamina,
+                           int acceleratorUsesPer3Seconds) {
+        this.maxSpeedKmh = maxSpeedKmh;
+        this.staminaDurationSeconds = staminaDurationSeconds;
+        this.recoverySecondsFor10PercentStamina = recoverySecondsFor10PercentStamina;
+        this.acceleratorUsesPer3Seconds = acceleratorUsesPer3Seconds;
+    }
+
+    public static CarPerformance fromAttributes(CarAttributes attributes) {
+        int maxSpeed = BASE_MAX_SPEED_KMH + (attributes.getSpeedPoints() * SPEED_PER_POINT_KMH);
+        int baseStamina = resolveBaseStamina(maxSpeed);
+        int staminaDuration = baseStamina + (attributes.getStaminaPoints() * STAMINA_PER_POINT_SECONDS);
+
+        int recoverySeconds = BASE_RECOVERY_SECONDS_FOR_10_PERCENT
+                - (attributes.getRecoveryPoints() * RECOVERY_REDUCTION_PER_POINT_SECONDS);
+        recoverySeconds = Math.max(0, recoverySeconds);
+
+        int acceleratorUses = attributes.getAcceleratorPoints() * ACCELERATOR_USES_PER_POINT_PER_3_SECONDS;
+
+        return new CarPerformance(maxSpeed, staminaDuration, recoverySeconds, acceleratorUses);
+    }
+
+    private static int resolveBaseStamina(int maxSpeed) {
+        if (maxSpeed < 50) {
+            return STAMINA_LOW_SPEED_SECONDS;
+        }
+        if (maxSpeed < 70) {
+            return STAMINA_MEDIUM_SPEED_SECONDS;
+        }
+        return STAMINA_HIGH_SPEED_SECONDS;
+    }
+
+    public int getMaxSpeedKmh() {
+        return maxSpeedKmh;
+    }
+
+    public int getStaminaDurationSeconds() {
+        return staminaDurationSeconds;
+    }
+
+    public int getRecoverySecondsFor10PercentStamina() {
+        return recoverySecondsFor10PercentStamina;
+    }
+
+    public int getAcceleratorUsesPer3Seconds() {
+        return acceleratorUsesPer3Seconds;
+    }
+}

--- a/src/main/java/com/calendar/game/RaceMatchConfig.java
+++ b/src/main/java/com/calendar/game/RaceMatchConfig.java
@@ -1,0 +1,45 @@
+package com.calendar.game;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RaceMatchConfig {
+    private static final int MIN_CARS = 4;
+    private static final int MAX_CARS = 10;
+    private static final List<Integer> ALLOWED_MATCH_ROUNDS = Arrays.asList(3, 5, 7);
+
+    private final int numberOfCars;
+    private final int roundsPerMatch;
+    private final RoundDistance roundDistance;
+
+    public RaceMatchConfig(int numberOfCars, int roundsPerMatch, RoundDistance roundDistance) {
+        this.numberOfCars = numberOfCars;
+        this.roundsPerMatch = roundsPerMatch;
+        this.roundDistance = roundDistance;
+        validate();
+    }
+
+    private void validate() {
+        if (numberOfCars < MIN_CARS || numberOfCars > MAX_CARS) {
+            throw new IllegalArgumentException("Number of cars must be between 4 and 10.");
+        }
+        if (!ALLOWED_MATCH_ROUNDS.contains(roundsPerMatch)) {
+            throw new IllegalArgumentException("Rounds per match must be 3, 5 or 7.");
+        }
+        if (roundDistance == null) {
+            throw new IllegalArgumentException("Round distance is required.");
+        }
+    }
+
+    public int getNumberOfCars() {
+        return numberOfCars;
+    }
+
+    public int getRoundsPerMatch() {
+        return roundsPerMatch;
+    }
+
+    public RoundDistance getRoundDistance() {
+        return roundDistance;
+    }
+}

--- a/src/main/java/com/calendar/game/RoundDistance.java
+++ b/src/main/java/com/calendar/game/RoundDistance.java
@@ -1,0 +1,17 @@
+package com.calendar.game;
+
+public enum RoundDistance {
+    FIVE_KM(5),
+    TEN_KM(10),
+    TWENTY_KM(20);
+
+    private final int kilometers;
+
+    RoundDistance(int kilometers) {
+        this.kilometers = kilometers;
+    }
+
+    public int getKilometers() {
+        return kilometers;
+    }
+}

--- a/src/test/java/com/calendar/game/RaceRulesTest.java
+++ b/src/test/java/com/calendar/game/RaceRulesTest.java
@@ -1,0 +1,44 @@
+package com.calendar.game;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RaceRulesTest {
+
+    @Test
+    public void shouldCalculatePerformanceFromAssignedPoints() {
+        CarAttributes attributes = new CarAttributes(4, 3, 2, 1);
+
+        CarPerformance performance = CarPerformance.fromAttributes(attributes);
+
+        assertEquals(100, performance.getMaxSpeedKmh());
+        assertEquals(35, performance.getStaminaDurationSeconds());
+        assertEquals(0, performance.getRecoverySecondsFor10PercentStamina());
+        assertEquals(1, performance.getAcceleratorUsesPer3Seconds());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectAttributeAssignmentsThatDoNotUseTenPoints() {
+        new CarAttributes(1, 2, 3, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectCarCountOutsideAllowedRange() {
+        new RaceMatchConfig(3, 3, RoundDistance.TEN_KM);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectRoundsOutsideAllowedValues() {
+        new RaceMatchConfig(6, 4, RoundDistance.FIVE_KM);
+    }
+
+    @Test
+    public void shouldAcceptValidRaceConfiguration() {
+        RaceMatchConfig config = new RaceMatchConfig(10, 7, RoundDistance.TWENTY_KM);
+
+        assertEquals(10, config.getNumberOfCars());
+        assertEquals(7, config.getRoundsPerMatch());
+        assertEquals(20, config.getRoundDistance().getKilometers());
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement game rules and validation for a racing car Android game following the provided requirements: selectable car count (4–10), selectable rounds (3/5/7), selectable per-round distances (5/10/20 km), and a 10-point attribute system affecting speed, stamina, recovery and accelerator.

### Description
- Added `CarAttributes` to represent speed, stamina, recovery and accelerator points and to enforce non-negative values and that exactly 10 points are assigned.
- Added `RaceMatchConfig` to validate match setup including allowed car counts, allowed rounds and required distance selection, and added `RoundDistance` enum for 5/10/20 km options.
- Added `CarPerformance` with formulas that compute max speed (base 80 + 5 km/h per speed point), stamina duration (speed-tier base 40/30/20s + 5s per stamina point), recovery time (base 2s for 10% stamina reduced by 3s per recovery point, clamped at 0) and accelerator uses (1 use per accelerator point per 3 seconds).
- Added `RaceRulesTest` unit tests covering valid performance calculation and validation failures for incorrect point totals, car counts, and rounds.

### Testing
- Created `RaceRulesTest` covering positive and negative scenarios for the new classes and assertions for computed performance values which are present in `src/test/java/com/calendar/game/RaceRulesTest.java`.
- Attempted to run `mvn -q -Dtest=RaceRulesTest test`, but the build failed due to a Maven plugin resolution error downloading plugins from `https://repo.maven.apache.org/maven2` (HTTP 403), so tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7c0564894832d815ecbf2a19e5ad3)